### PR TITLE
Update our thinking on pre-activation restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We envision prerendering having several related pieces:
 
 * [**Prerendering browsing contexts**](./browsing-context.md), which are special browsing contexts that are not displayed to the user, and within which content is constrained to not perform disruptive or side-effecting operations.
 
-  In all prerendering browsing contexts, side-effecting or disruptive APIs, such as those that could play media, require a permission prompt, or otherwise display UI, will be disabled in API-specific ways. In those tagged as being used for cross-origin prerendering, storage access will not be available, and all fetches will need to use the prerendering fetching modes.
+  In all prerendering browsing contexts, disruptive APIs, such as those that could play media, require a permission prompt, or otherwise display UI, will be disabled in API-specific ways. In those tagged as being used for cross-origin prerendering, storage access will not be available, and all fetches will need to use the prerendering fetching modes.
 
   Crucially, prerendering browsing contexts have the ability to transition to becoming normal top-level browsing contexts, so that all of the prerendered content is reused and immediately displayed to the user.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We envision prerendering having several related pieces:
 
 * [**Prerendering browsing contexts**](./browsing-context.md), which are special browsing contexts that are not displayed to the user, and within which content is constrained to not perform disruptive or side-effecting operations.
 
-  In all prerendering browsing contexts, side-effecting or disruptive APIs, such as those that could play media, require a permission prompt, or otherwise display UI, will automatically error or no-op. In those tagged as being used for cross-origin prerendering, storage access will not be available (or, perhaps, is partitioned?), and all fetches will need to use the prerendering fetching modes.
+  In all prerendering browsing contexts, side-effecting or disruptive APIs, such as those that could play media, require a permission prompt, or otherwise display UI, will be disabled in API-specific ways. In those tagged as being used for cross-origin prerendering, storage access will not be available, and all fetches will need to use the prerendering fetching modes.
 
   Crucially, prerendering browsing contexts have the ability to transition to becoming normal top-level browsing contexts, so that all of the prerendered content is reused and immediately displayed to the user.
 

--- a/index.bs
+++ b/index.bs
@@ -59,6 +59,8 @@ Every {{Document}} has a <dfn for="Document">prerendering browsing contexts map<
 
 <p class="issue">Should this map be scoped to the [=user agent=] instead? Or, allowed to be copied between documents?
 
+Every {{Document}} has a <dfn for="Document">post-activation steps list</dfn>, which is a [=list=] where each [=list/item=] is a series of algorithm steps.
+
 <div algorithm="create a prerendering browsing context">
   To <dfn export>create a prerendering browsing context</dfn> given a [=URL=] |startingURL|, a [=referrer policy=] |referrerPolicy|, and a {{Document}} |referrerDoc|:
 
@@ -108,6 +110,10 @@ Every {{Document}} has a <dfn for="Document">prerendering browsing contexts map<
     1. [=Queue a global task=] on the [=networking task source=] given |successorBC|'s [=browsing context/active window=] to perform the following steps
 
       1. Set |successorBC|'s [=browsing context/loading mode=] to "`default`".
+
+      1. [=list/For each=] |steps| in |successorBC|'s [=active document=]'s [=Document/post-activation steps list=], run |steps|.
+
+      1. [=list/Empty=] |successorBC|'s [=active document=]'s [=Document/post-activation steps list=].
 </div>
 
 <h2 id="navigation">Navigation and session history</h2>
@@ -188,6 +194,14 @@ Patch the [=navigate=] algorithm to prevent certain navigations in a [=prerender
   1. Otherwise, if <var ignore>browsingContext</var> is a [=prerendering browsing context=], then return.
 </div>
 
+<h3 id="cleanup-upon-discarding">Cleanup upon discarding a {{Document}}</h3>
+
+Modify the [=discard a document|discard=] algorithm for {{Document}}s by appending the following step:
+
+<div algorithm="discard a Document patch">
+  1. [=list/Empty=] <var ignore>document</var>'s [=Document/post-activation steps list=].
+</div>
+
 <h2 id="nonsense-behaviors">Preventing nonsensical behaviors</h2>
 
 Some behaviors might make sense in most [=top-level browsing contexts=], but do not make sense in [=prerendering browsing contexts=]. This section enumerates specification patches to enforce such restrictions.
@@ -207,12 +221,10 @@ Various behaviors are disallowed in [=prerendering browsing contexts=] because t
 
 <h3 id="patch-downloading">Downloading resources</h3>
 
-Modify the <a spec=HTML>allowed to download</a> algorithm to ensure that prerendered content never performs downloads, by prepending the following steps:
+Modify the <a spec=HTML>downloads a hyperlink</a> algorithm to ensure that downloads inside [=prerendering browsing contexts=] are delayed until [=prerendering browsing context/activate|activation=], by inserting the following before the step which goes [=in parallel=]:
 
-<div algorithm="allowed to download patch">
-  1. If <var ignore>initiator browsing context</var> is a [=prerendering browsing context=], then return false.
-
-  1. If <var ignore>instantiator browsing context</var> is a [=prerendering browsing context=], then return false.
+<div algorithm="downloads a hyperlink patch">
+  1. If <var ignore>subject</var>'s [=Node/node document=]'s [=Document/browsing context=] is a [=prerendering browsing context=], then append the following step to <var ignore>subject</var>'s [=Node/node document=]'s [=Document/post-activation steps list=] and return.
 </div>
 
 <h2 id="todo">TODO</h2>

--- a/index.bs
+++ b/index.bs
@@ -59,7 +59,7 @@ Every {{Document}} has a <dfn for="Document">prerendering browsing contexts map<
 
 <p class="issue">Should this map be scoped to the [=user agent=] instead? Or, allowed to be copied between documents?
 
-Every {{Document}} has a <dfn for="Document">post-activation steps list</dfn>, which is a [=list=] where each [=list/item=] is a series of algorithm steps.
+Every {{Document}} has a <dfn for="Document">post-prerendering activation steps list</dfn>, which is a [=list=] where each [=list/item=] is a series of algorithm steps.
 
 <div algorithm="create a prerendering browsing context">
   To <dfn export>create a prerendering browsing context</dfn> given a [=URL=] |startingURL|, a [=referrer policy=] |referrerPolicy|, and a {{Document}} |referrerDoc|:
@@ -111,9 +111,13 @@ Every {{Document}} has a <dfn for="Document">post-activation steps list</dfn>, w
 
       1. Set |successorBC|'s [=browsing context/loading mode=] to "`default`".
 
-      1. [=list/For each=] |steps| in |successorBC|'s [=active document=]'s [=Document/post-activation steps list=], run |steps|.
+      1. [=list/For each=] |steps| in |successorBC|'s [=active document=]'s [=Document/post-prerendering activation steps list=]:
 
-      1. [=list/Empty=] |successorBC|'s [=active document=]'s [=Document/post-activation steps list=].
+        1. Run |steps|.
+
+        1. Assert: running |steps| did not throw an exception.
+
+      1. [=list/Empty=] |successorBC|'s [=active document=]'s [=Document/post-prerendering activation steps list=].
 </div>
 
 <h2 id="navigation">Navigation and session history</h2>
@@ -199,7 +203,7 @@ Patch the [=navigate=] algorithm to prevent certain navigations in a [=prerender
 Modify the [=discard a document|discard=] algorithm for {{Document}}s by appending the following step:
 
 <div algorithm="discard a Document patch">
-  1. [=list/Empty=] <var ignore>document</var>'s [=Document/post-activation steps list=].
+  1. [=list/Empty=] <var ignore>document</var>'s [=Document/post-prerendering activation steps list=].
 </div>
 
 <h2 id="nonsense-behaviors">Preventing nonsensical behaviors</h2>
@@ -224,7 +228,7 @@ Various behaviors are disallowed in [=prerendering browsing contexts=] because t
 Modify the <a spec=HTML>downloads a hyperlink</a> algorithm to ensure that downloads inside [=prerendering browsing contexts=] are delayed until [=prerendering browsing context/activate|activation=], by inserting the following before the step which goes [=in parallel=]:
 
 <div algorithm="downloads a hyperlink patch">
-  1. If <var ignore>subject</var>'s [=Node/node document=]'s [=Document/browsing context=] is a [=prerendering browsing context=], then append the following step to <var ignore>subject</var>'s [=Node/node document=]'s [=Document/post-activation steps list=] and return.
+  1. If <var ignore>subject</var>'s [=Node/node document=]'s [=Document/browsing context=] is a [=prerendering browsing context=], then append the following step to <var ignore>subject</var>'s [=Node/node document=]'s [=Document/post-prerendering activation steps list=] and return.
 </div>
 
 <h2 id="todo">TODO</h2>


### PR DESCRIPTION
This follows much of the discussion in https://docs.google.com/document/d/1zY15k_wFTik2EoxBf3_RT7YjYpFMDaeNspy15n0rtww/edit?usp=sharing, porting that to the explainer.

The specification is updated for the single so-far-specified restriction, of downloads, to show how we might specify the others.

Potential reviewers: @jeremyroman, @jakearchibald, @domfarolino