### PR TITLE
Add a simple prerender processing model

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12,6 +12,9 @@ Complain About: accidental-2119 yes, missing-example-ids yes
 Indent: 2
 Boilerplate: omit conformance
 </pre>
+<pre class="link-defaults">
+spec:html; type:element; text:link
+</pre>
 <pre class="anchors">
 spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
   type: dfn
@@ -30,14 +33,9 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: abort; for: Document; url: abort-a-document
       text: create and initialize a Document object; url: initialise-the-document-object
       text: history handling behavior; url: history-handling-behavior
-      text: link; url: the-link-element
       text: prompt to unload; url: prompt-to-unload-a-document
       text: refused to allow the document to be unloaded; url: refused-to-allow-the-document-to-be-unloaded
       text: traverse the history; url: traverse-the-history
-    urlPrefix: semantics.html
-      for: link
-        text: href; url: attr-link-href
-        text: referrerpolicy; url: attr-link-referrerpolicy
     urlPrefix: urls-and-fetching.html
       text: parse a URL; url: parse-a-url
       text: resulting URL record
@@ -45,7 +43,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
 
 <h2 id="prerendering-bcs">Prerendering browsing contexts</h2>
 
-<em>The following section would be added as a new sub-section of [[HTML]]'s <a href="https://html.spec.whatwg.org/#windows">Browsing contexts</a> section.</em>
+<em>The following section would be added as a new sub-section of [[HTML]]'s <a href="https://html.spec.whatwg.org/multipage/browsers.html#windows">Browsing contexts</a> section.</em>
 
 Every [=browsing context=] has a <dfn for="browsing context">loading mode</dfn>, which is one of the following:
 
@@ -86,8 +84,6 @@ Every {{Document}} has a <dfn for="Document">post-prerendering activation steps 
   1. Let |request| be a new [=request=] whose [=request/URL=] is |startingURL| and [=request/referrer policy=] is |referrerPolicy|.
 
   1. [=Navigate=] |bc| to |request| with the [=source browsing context=] set to |referrerDoc|'s [=Document/browsing context=].
-
-  1. Return |bc|.
 </div>
 
 <div algorithm>
@@ -149,22 +145,27 @@ The <dfn attribute for="Document">prerendering</dfn> getter steps are to return 
 The <dfn attribute for="Document">onprerenderingchange</dfn> attribute is an [=event handler IDL attribute=] corresponding to the <dfn event for="Document">prerenderingchange</dfn> [=event handler event type=].
 
 
-<h2 id="prerender-processing-model">Prerender processing model</h2>
+<h2 id="link-rel-prerender">Link type "<dfn attr-value for="link/rel"><code>prerender</code></dfn>"</h2>
 
-Add a new link type to the "Link types" section of the HTML Standard, replacing the prerender documentation in the Resource Hints standard.
+<em>The following section would be added as a new sub-section of [[HTML]]'s <a href="https://html.spec.whatwg.org/multipage/links.html#linkTypes">Link types</a> section. This should replace the prerender documentation in the Resource Hints standard</em>
 
-<h3 id="link-rel-prerender">Link type "<dfn data-lt="rel-prerender"><code>prerender</code></dfn>"</h3>
-
-The <a lt="rel-prerender"><code>prerender</code></a> keyword may be used with <a spec=HTML><code>link</code></a> elements. This keyword creates an <a spec=HTML>external resource link</a>. This keyword is <a spec=HTML>body-ok</a>.
-
-To <a lt="process the linked resource" spec=HTML>process this type of linked resource</a> given a <a spec=HTML><code>link</code></a> element <var ignore>el</var>, run these steps:
+The <{link/rel/prerender}> keyword may be used with <{link}> elements. This keyword creates an <a spec=HTML>external resource link</a>. This keyword is <a spec=HTML>body-ok</a>.
 
 <div algorithm="prerender-processing-model">
-  1. If |el|'s [=link/href=] attribute's value is the empty string, then return.
-  1. Let |referrer policy| be  the current state of |el|'s [=link/referrerpolicy=] attribute.
-  1. [=parse a URL|Parse=] the [=URL=] given by |el|'s [=link/href=] attribute, relative to |el|'s [=Node/node document=]. If that fails, then return. Otherwise, let |url| be the [=resulting URL record=].
+  To <a lt="fetch and process the linked resource" spec=HTML>fetch and process this type of linked resource</a> given a <{link}> element <var>el</var>, run these steps:
+
+  1. If |el|'s <{link/href}> attribute's value is the empty string, then return.
+
+  1. Let |referrer policy| be  the current state of |el|'s <{link/referrerpolicy}> attribute.
+
+  1. [=Parse a URL=] given by |el|'s <{link/href}> attribute, relative to |el|'s [=Node/node document=]. If that fails, then return. Otherwise, let |url| be the [=resulting URL record=].
+
   1. [=Create a prerendering browsing context=] with |url|, |referrer policy|, and |el|'s [=Node/node document=].
 </div>
+
+A user agent must not <a spec=HTML>delay the load event</a> of the <{link}> element's <a for=Node>node document</a> for this link type.
+
+<p class="note">Note that this type of link does not fire {{HTMLElement/error}} or {{HTMLElement/load}} events, unlike many other links that create an <a spec=HTML>external resource links</a>.
 
 <p class="issue">TODO: We should define a list of allowable referrer policies to prerender with, and early-return if the above referrer policy is not in this list.
 

--- a/index.bs
+++ b/index.bs
@@ -41,6 +41,39 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: resulting URL record
 </pre>
 
+<h2 id="link-rel-prerender">Link type "<dfn attr-value for="link/rel"><code>prerender</code></dfn>"</h2>
+
+<em>The following section would be added as a new sub-section of [[HTML]]'s <a href="https://html.spec.whatwg.org/multipage/links.html#linkTypes">Link types</a> section. This should replace the prerender documentation in the Resource Hints standard</em>
+
+The <{link/rel/prerender}> keyword may be used with <{link}> elements. This keyword creates an <a spec=HTML>external resource link</a>. This keyword is <a spec=HTML>body-ok</a>.
+
+The appropriate times to <a spec=HTML>fetch and process the linked resource</a> for such a link are:
+
+<ul>
+  <li>When the <a spec=HTML>external resource link</a> is created on a <{link}> element that is already <a spec=HTML>browsing-context connected</a>.</li>
+  <li>When the <a spec=HTML>external resource link</a>'s <{link}> element <a spec=HTML>becomes browsing-context connected</a>.</li>
+  <li>When the <{link/href}> attribute of the <{link}> element of an <a spec=HTML>external resource link</a> that is already <a spec=HTML>browsing-context connected</a> is changed.</li>
+</ul>
+
+<div algorithm="prerender-processing-model">
+  The <a spec=HTML>fetch and process the linked resource</a> algorithm for <{link/rel/prerender}> links, given a <{link}> element <var>el</var>, is as follows:
+
+  1. If |el|'s <{link/href}> attribute's value is the empty string, then return.
+
+  1. [=Parse a URL=] given |el|'s <{link/href}> attribute, relative to |el|'s [=Node/node document=]. If that fails, then return. Otherwise, let |url| be the [=resulting URL record=].
+
+  1. Let |referrer policy| be  the current state of |el|'s <{link/referrerpolicy}> attribute.
+
+  1. [=Create a prerendering browsing context=] with |url|, |referrer policy|, and |el|'s [=Node/node document=].
+</div>
+
+A user agent must not <a spec=HTML>delay the load event</a> of the <{link}> element's <a for=Node>node document</a> for this link type.
+
+<p class="note">Note that this type of link does not fire {{HTMLElement/error}} or {{HTMLElement/load}} events, unlike many other links that create an <a spec=HTML>external resource links</a>.
+
+<p class="issue">TODO: We should define a list of allowable referrer policies to prerender with, and early-return if the above referrer policy is not in this list.
+
+
 <h2 id="prerendering-bcs">Prerendering browsing contexts</h2>
 
 <em>The following section would be added as a new sub-section of [[HTML]]'s <a href="https://html.spec.whatwg.org/multipage/browsers.html#windows">Browsing contexts</a> section.</em>
@@ -144,38 +177,6 @@ The <dfn attribute for="Document">prerendering</dfn> getter steps are to return 
 
 The <dfn attribute for="Document">onprerenderingchange</dfn> attribute is an [=event handler IDL attribute=] corresponding to the <dfn event for="Document">prerenderingchange</dfn> [=event handler event type=].
 
-
-<h2 id="link-rel-prerender">Link type "<dfn attr-value for="link/rel"><code>prerender</code></dfn>"</h2>
-
-<em>The following section would be added as a new sub-section of [[HTML]]'s <a href="https://html.spec.whatwg.org/multipage/links.html#linkTypes">Link types</a> section. This should replace the prerender documentation in the Resource Hints standard</em>
-
-The <{link/rel/prerender}> keyword may be used with <{link}> elements. This keyword creates an <a spec=HTML>external resource link</a>. This keyword is <a spec=HTML>body-ok</a>.
-
-The appropriate times to <a spec=HTML>fetch and process the linked resource</a> for such a link are:
-
-<ul>
-  <li>When the <a spec=HTML>external resource link</a> is created on a <{link}> element that is already <a spec=HTML>browsing-context connected</a>.</li>
-  <li>When the <a spec=HTML>external resource link</a>'s <{link}> element <a spec=HTML>becomes browsing-context connected</a>.</li>
-  <li>When the <{link/href}> attribute of the <{link}> element of an <a spec=HTML>external resource link</a> that is already <a spec=HTML>browsing-context connected</a> is changed.</li>
-</ul>
-
-<div algorithm="prerender-processing-model">
-  The <a spec=HTML>fetch and process the linked resource</a> algorithm for <{link/rel/prerender}> links, given a <{link}> element <var>el</var>, is as follows:
-
-  1. If |el|'s <{link/href}> attribute's value is the empty string, then return.
-
-  1. [=Parse a URL=] given |el|'s <{link/href}> attribute, relative to |el|'s [=Node/node document=]. If that fails, then return. Otherwise, let |url| be the [=resulting URL record=].
-
-  1. Let |referrer policy| be  the current state of |el|'s <{link/referrerpolicy}> attribute.
-
-  1. [=Create a prerendering browsing context=] with |url|, |referrer policy|, and |el|'s [=Node/node document=].
-</div>
-
-A user agent must not <a spec=HTML>delay the load event</a> of the <{link}> element's <a for=Node>node document</a> for this link type.
-
-<p class="note">Note that this type of link does not fire {{HTMLElement/error}} or {{HTMLElement/load}} events, unlike many other links that create an <a spec=HTML>external resource links</a>.
-
-<p class="issue">TODO: We should define a list of allowable referrer policies to prerender with, and early-return if the above referrer policy is not in this list.
 
 <h2 id="navigation">Navigation and session history</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -70,7 +70,7 @@ The appropriate times to <a spec=HTML>fetch and process the linked resource</a> 
 
 A user agent must not <a spec=HTML>delay the load event</a> of the <{link}> element's <a for=Node>node document</a> for this link type.
 
-<p class="note">Note that this type of link does not fire {{HTMLElement/error}} or {{HTMLElement/load}} events, unlike many other links that create an <a spec=HTML>external resource links</a>.
+<p class="note">Note that this link type does not fire {{HTMLElement/error}} or {{HTMLElement/load}} events, unlike many other link types that create <a spec=HTML>external resource links</a>.
 
 <p class="issue">TODO: We should define a list of allowable referrer policies to prerender with, and early-return if the above referrer policy is not in this list.
 

--- a/index.bs
+++ b/index.bs
@@ -151,8 +151,16 @@ The <dfn attribute for="Document">onprerenderingchange</dfn> attribute is an [=e
 
 The <{link/rel/prerender}> keyword may be used with <{link}> elements. This keyword creates an <a spec=HTML>external resource link</a>. This keyword is <a spec=HTML>body-ok</a>.
 
+The appropriate times to <a spec=HTML>fetch and process the linked resource</a> for such a link are:
+
+<ul>
+  <li>When the <a spec=HTML>external resource link</a> is created on a <{link}> element that is already <a spec=HTML>browsing-context connected</a>.</li>
+  <li>When the <a spec=HTML>external resource link</a>'s <{link}> element <a spec=HTML>becomes browsing-context connected</a>.</li>
+  <li>When the <{link/href}> attribute of the <{link}> element of an <a spec=HTML>external resource link</a> that is already <a spec=HTML>browsing-context connected</a> is changed.</li>
+</ul>
+
 <div algorithm="prerender-processing-model">
-  To <a lt="fetch and process the linked resource" spec=HTML>fetch and process this type of linked resource</a> given a <{link}> element <var>el</var>, run these steps:
+  The <a spec=HTML>fetch and process the linked resource</a> algorithm for <{link/rel/prerender}> links, given a <{link}> element <var>el</var>, is as follows:
 
   1. If |el|'s <{link/href}> attribute's value is the empty string, then return.
 

--- a/index.bs
+++ b/index.bs
@@ -4,6 +4,7 @@ Shortname: prerendering-revamped
 Status: DREAM
 Repository: jeremyroman/alternate-loading-modes
 Editor: Domenic Denicola, Google https://www.google.com/, d@domenic.me
+Editor: Dominic Farolino, Google https://www.google.com/, domfarolino@gmail.com
 Abstract: This document contains a collection of specification patches for well-specified prerendering.
 Markup Shorthands: css no, markdown yes
 Assume Explicit For: yes
@@ -29,9 +30,17 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: abort; for: Document; url: abort-a-document
       text: create and initialize a Document object; url: initialise-the-document-object
       text: history handling behavior; url: history-handling-behavior
+      text: link; url: the-link-element
       text: prompt to unload; url: prompt-to-unload-a-document
       text: refused to allow the document to be unloaded; url: refused-to-allow-the-document-to-be-unloaded
       text: traverse the history; url: traverse-the-history
+    urlPrefix: semantics.html
+      for: link
+        text: href; url: attr-link-href
+        text: referrerpolicy; url: attr-link-referrerpolicy
+    urlPrefix: urls-and-fetching.html
+      text: parse a URL; url: parse-a-url
+      text: resulting URL record
 </pre>
 
 <h2 id="prerendering-bcs">Prerendering browsing contexts</h2>
@@ -139,6 +148,25 @@ The <dfn attribute for="Document">prerendering</dfn> getter steps are to return 
 
 The <dfn attribute for="Document">onprerenderingchange</dfn> attribute is an [=event handler IDL attribute=] corresponding to the <dfn event for="Document">prerenderingchange</dfn> [=event handler event type=].
 
+
+<h2 id="prerender-processing-model">Prerender processing model</h2>
+
+Add a new link type to the "Link types" section of the HTML Standard, replacing the prerender documentation in the Resource Hints standard.
+
+<h3 id="link-rel-prerender">Link type "<dfn data-lt="rel-prerender"><code>prerender</code></dfn>"</h3>
+
+The <a lt="rel-prerender"><code>prerender</code></a> keyword may be used with <a spec=HTML><code>link</code></a> elements. This keyword creates an <a spec=HTML>external resource link</a>. This keyword is <a spec=HTML>body-ok</a>.
+
+To <a lt="process the linked resource" spec=HTML>process this type of linked resource</a> given a <a spec=HTML><code>link</code></a> element <var ignore>el</var>, run these steps:
+
+<div algorithm="prerender-processing-model">
+  1. If |el|'s [=link/href=] attribute's value is the empty string, then return.
+  1. Let |referrer policy| be  the current state of |el|'s [=link/referrerpolicy=] attribute.
+  1. [=parse a URL|Parse=] the [=URL=] given by |el|'s [=link/href=] attribute, relative to |el|'s [=Node/node document=]. If that fails, then return. Otherwise, let |url| be the [=resulting URL record=].
+  1. [=Create a prerendering browsing context=] with |url|, |referrer policy|, and |el|'s [=Node/node document=].
+</div>
+
+<p class="issue">TODO: We should define a list of allowable referrer policies to prerender with, and early-return if the above referrer policy is not in this list.
 
 <h2 id="navigation">Navigation and session history</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -166,7 +166,7 @@ The appropriate times to <a spec=HTML>fetch and process the linked resource</a> 
 
   1. Let |referrer policy| be  the current state of |el|'s <{link/referrerpolicy}> attribute.
 
-  1. [=Parse a URL=] given by |el|'s <{link/href}> attribute, relative to |el|'s [=Node/node document=]. If that fails, then return. Otherwise, let |url| be the [=resulting URL record=].
+  1. [=Parse a URL=] given |el|'s <{link/href}> attribute, relative to |el|'s [=Node/node document=]. If that fails, then return. Otherwise, let |url| be the [=resulting URL record=].
 
   1. [=Create a prerendering browsing context=] with |url|, |referrer policy|, and |el|'s [=Node/node document=].
 </div>

--- a/index.bs
+++ b/index.bs
@@ -164,9 +164,9 @@ The appropriate times to <a spec=HTML>fetch and process the linked resource</a> 
 
   1. If |el|'s <{link/href}> attribute's value is the empty string, then return.
 
-  1. Let |referrer policy| be  the current state of |el|'s <{link/referrerpolicy}> attribute.
-
   1. [=Parse a URL=] given |el|'s <{link/href}> attribute, relative to |el|'s [=Node/node document=]. If that fails, then return. Otherwise, let |url| be the [=resulting URL record=].
+
+  1. Let |referrer policy| be  the current state of |el|'s <{link/referrerpolicy}> attribute.
 
   1. [=Create a prerendering browsing context=] with |url|, |referrer policy|, and |el|'s [=Node/node document=].
 </div>

--- a/index.bs
+++ b/index.bs
@@ -43,16 +43,17 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
 
 <h2 id="link-rel-prerender">Link type "<dfn attr-value for="link/rel"><code>prerender</code></dfn>"</h2>
 
-<em>The following section would be added as a new sub-section of [[HTML]]'s <a href="https://html.spec.whatwg.org/multipage/links.html#linkTypes">Link types</a> section. This should replace the prerender documentation in the Resource Hints standard</em>
+<em>The following section would be added as a new sub-section of [[HTML]]'s <a href="https://html.spec.whatwg.org/multipage/links.html#linkTypes">Link types</a> section. This should replace the prerender documentation in [[RESOURCE-HINTS]]</em>
 
 The <{link/rel/prerender}> keyword may be used with <{link}> elements. This keyword creates an <a spec=HTML>external resource link</a>. This keyword is <a spec=HTML>body-ok</a>.
 
 The appropriate times to <a spec=HTML>fetch and process the linked resource</a> for such a link are:
 
 <ul>
-  <li>When the <a spec=HTML>external resource link</a> is created on a <{link}> element that is already <a spec=HTML>browsing-context connected</a>.</li>
-  <li>When the <a spec=HTML>external resource link</a>'s <{link}> element <a spec=HTML>becomes browsing-context connected</a>.</li>
-  <li>When the <{link/href}> attribute of the <{link}> element of an <a spec=HTML>external resource link</a> that is already <a spec=HTML>browsing-context connected</a> is changed.</li>
+  <li>When the <a spec=HTML>external resource link</a> is created on a <{link}> element that is already [=browsing-context connected=]</a>.</li>
+  <li>When the <a spec=HTML>external resource link</a>'s <{link}> element [=becomes browsing-context connected=].</li>
+  <li>When the <{link/href}> attribute is changed on the <{link}> element of an [=external resource link=] that is already [=browsing-context connected=].</li>
+  <li>When the <{link/referrerpolicy}> attribute's state is changed on the <{link}> element of an [=external resource link=] that is already [=browsing-context connected=].</li>
 </ul>
 
 <div algorithm="prerender-processing-model">


### PR DESCRIPTION
This PR adds a simple "starter" `<link rel=prerender>` processing model section that:
 - Defines the new `rel=prerender` link type that establishes an [#external-resource-link](https://html.spec.whatwg.org/multipage/links.html#external-resource-link)
 - Overrides the [#default-fetch-and-process-the-linked-resource] algorithm for this link type to create a prerendering browsing context
 - Adds reasonable (at the time of writing this) "appropriate times" to invoke the processing model algorithm (these appropriate times are somewhat inspired from other link types in the HTML Standard)
 - Documents the fact that soon we're going to define a "sufficiently strict referrer policy set" which will be used to restrict prerenders to those whose `referrerpolicy` attr is in the set