### PR TITLE
Remove issue text about prerendering browsing context map scoping

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -98,8 +98,6 @@ A [=prerendering browsing context=] is <dfn for="prerendering browsing context">
 
 Every {{Document}} has a <dfn for="Document">prerendering browsing contexts map</dfn>, which is an [=ordered map=] of ([=URL=], [=referrer policy=]) [=tuples=] to [=prerendering browsing contexts=]. This is used to fulfill [=navigate|navigations=] to a given URL by instead [=prerendering browsing context/activating=] the corresponding prerendering browsing context.
 
-<p class="issue">Should this map be scoped to the [=user agent=] instead? Or, allowed to be copied between documents?
-
 Every {{Document}} has a <dfn for="Document">post-prerendering activation steps list</dfn>, which is a [=list=] where each [=list/item=] is a series of algorithm steps.
 
 <div algorithm="create a prerendering browsing context">


### PR DESCRIPTION
The issue text "Should this map be scoped to the user agent instead? Or, allowed to be copied between documents?" aims to track further discussion about what the right scoping for the prerendering browsing context map would be. I believe that discussion is already tracked and being carried out in [Prerendering activation matching](https://docs.google.com/document/d/1E82ZqXibjCvpPdOgMmOfPIatPMEBVAiJ2KQm6r1_E94/edit#), and as a result of that early discussion we've tentatively decided to settle on a document-scoping, thus landing on the currently-spec'd solution. So I vote we remove this issue text from the spec.