### PR TITLE
First draft of a spec for speculation rules for prefetch

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -200,6 +200,8 @@ Periodically, for any [=document=] |document|, the user agent may [=queue a glob
 <div algorithm="consider speculation">
   To <dfn>consider speculation</dfn> for a [=document=] |document|:
 
+  1. If |document| is not [=Document/fully active=], then return.
+     <p class="issue">It's likely that we should also handle prerendered and back-forward cached documents.
   1. For each |ruleSet| of |document|'s [=document/list of speculation rule sets=]:
     1. [=list/For each=] |rule| of |ruleSet|'s [=speculation rule set/prefetch rules=]:
       1. Let |requiresAnonymousClientIP| be true if |rule|'s [=speculation rule/requirements=] [=set/contains=] "`anonymous-client-ip`", and false otherwise.

--- a/index.bs
+++ b/index.bs
@@ -205,7 +205,7 @@ Periodically, the user agent may [=queue a task=] to the <a data-link-type="inte
       1. Let |requiresAnonymousClientIP| be true if |rule|'s [=speculation rule/requirements=] [=set/contains=] "`anonymous-client-ip`", and false otherwise.
       1. [=list/For each=] |url| of |rule|'s [=speculation rule/URLs=]:
         1. The user agent may prefetch |url| given |requiresAnonymousClientIP|.
-           <p class="issue">TODO: expand this to actually elaborate on how prefetch works, once initiated, and to incorporate the |requiresAnonymousClientIP| flag.
+           <p class="issue">TODO: expand this to actually elaborate on how prefetch works, once initiated, and to incorporate the |requiresAnonymousClientIP| flag. We may wish to include language about when the UA should deduplicate requests.
 </div>
 
 <p class="issue">

--- a/index.bs
+++ b/index.bs
@@ -156,7 +156,7 @@ Inside the [=prepare a script=] algorithm we make the following changes:
 <div algorithm="parse speculation rules">
   To <dfn>parse speculation rules</dfn> given a [=string=] |input| and a [=URL=] |baseURL|, perform the following steps. They return a [=speculation rule set=] or null.
 
-  1. Let |parsed| be the result of [=Parse JSON into Infra values|parsing JSON into Infra values=] given |input|.
+  1. Let |parsed| be the result of [=parsing a JSON string to an Infra value=] given |input|.
   1. If |parsed| is not a [=map=], then return null.
   1. Let |result| be an empty [=speculation rule set=].
   1. If |parsed|["`prefetch`"] [=map/exists=] and is a [=list=], then [=list/for each=] |prefetchRule| of |parsed|["`prefetch`"]:
@@ -187,12 +187,12 @@ Inside the [=prepare a script=] algorithm we make the following changes:
   1. Return a [=speculation rule=] with [=speculation rule/URLs=] |urls| and [=speculation rule/requirements=] |requirements|.
 </div>
 
-<h3 id="speculation-rules-processing">Processing Model</h3>
+<h3 id="speculation-rules-processing">Processing model</h3>
 
 A [=document=] has a <dfn for=document export>list of speculation rule sets</dfn>, which is an initially empty [=list=].
 
 <!-- TODO(domfarolino): Get rid of the `data-link-type="interface"` once we fix the dfn in HTML. -->
-Periodically, the user agent may [=queue a task=] to the <a data-link-type="interface">DOM manipulation task source</a> to [=consider speculation=] for any [=document=].
+Periodically, for any [=document=] |document|, the user agent may [=queue a global task=] on the <a data-link-type="interface">DOM manipulation task source</a> with |document|'s [=relevant global object=] to [=consider speculation=] for |document|.
 
 <p class="note">
   The user agent will likely do this after the insertion of new speculation rules, or when resources are idle and available.

--- a/index.bs
+++ b/index.bs
@@ -154,7 +154,7 @@ Inside the [=prepare a script=] algorithm we make the following changes:
   This reduces the risk of unintended activity by user agents which are unaware of most recently added directives which might limit the scope of a rule.
 
 <div algorithm="parse speculation rules">
-  To <dfn export>parse speculation rules</dfn> given a [=string=] |input| and a [=URL=] |baseURL|, perform the following steps. They return a [=speculation rule set=] or null.
+  To <dfn>parse speculation rules</dfn> given a [=string=] |input| and a [=URL=] |baseURL|, perform the following steps. They return a [=speculation rule set=] or null.
 
   1. Let |parsed| be the result of [=Parse JSON into Infra values|parsing JSON into Infra values=] given |input|.
   1. If |parsed| is not a [=map=], then return null.
@@ -168,7 +168,7 @@ Inside the [=prepare a script=] algorithm we make the following changes:
 </div>
 
 <div algorithm="parse a speculation rule">
-  To <dfn export>parse a speculation rule</dfn> given a [=map=] |input| and a [=URL=] |baseURL|, perform the following steps. They return a [=speculation rule=] or null.
+  To <dfn>parse a speculation rule</dfn> given a [=map=] |input| and a [=URL=] |baseURL|, perform the following steps. They return a [=speculation rule=] or null.
 
   1. If |input| has any [=map/key=] other than "`source`", "`urls`", and "`requires`", then return null.
   1. If |input|["`source`"] does not [=map/exist=] or is not the [=string=] "`list`", then return null.
@@ -198,7 +198,7 @@ Periodically, the user agent may [=queue a task=] to the <a data-link-type="inte
   The user agent will likely do this after the insertion of new speculation rules, or when resources are idle and available.
 
 <div algorithm="consider speculation">
-  To <dfn export>consider speculation</dfn> for a [=document=] |document|:
+  To <dfn>consider speculation</dfn> for a [=document=] |document|:
 
   1. For each |ruleSet| of |document|'s [=document/list of speculation rule sets=]:
     1. [=list/For each=] |rule| of |ruleSet|'s [=speculation rule set/prefetch rules=]:

--- a/index.bs
+++ b/index.bs
@@ -204,7 +204,7 @@ Periodically, the user agent may [=queue a task=] to the <a data-link-type="inte
     1. [=list/For each=] |rule| of |ruleSet|'s [=speculation rule set/prefetch rules=]:
       1. Let |requiresAnonymousClientIP| be true if |rule|'s [=speculation rule/requirements=] [=set/contains=] "`anonymous-client-ip`", and false otherwise.
       1. [=list/For each=] |url| of |rule|'s [=speculation rule/URLs=]:
-        1. The user agent MAY prefetch |url| given |requiresAnonymousClientIP|.
+        1. The user agent may prefetch |url| given |requiresAnonymousClientIP|.
            <p class="issue">TODO: expand this to actually elaborate on how prefetch works, once initiated, and to incorporate the |requiresAnonymousClientIP| flag.
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -100,7 +100,7 @@ A <dfn>speculation rule set</dfn> is a [=struct=] with the following [=struct/it
 
 Add "`speculationrules`" to the list of valid values for <a spec=html>the script's type</a>.
 
-Rename [=the script's script=] to <dfn>the script's result</dfn>, which can be a [=speculation rule set=] in addition to any other valid type.
+Rename [=the script's script=] to <dfn>the script's result</dfn>, which can be either a script or a [=speculation rule set=].
 
 Inside the [=prepare a script=] algorithm:
 
@@ -113,15 +113,23 @@ Inside the [=prepare a script=] algorithm:
     <dd>
       1. Let |result| be the result of [=parse speculation rules|parsing speculation rules=] given source text and base URL.
 
-      1. If |result| is not null, set [=the script's result=] to |result|.
+      1. Set [=the script's result=] to |result|.
 
       1. <a spec=html>The script is ready</a>.
     </dd>
   </dl>
 
-Inside the <a spec=html>execute a script block</a> algorithm:
+* Insert the following case to the switch in the subsequent step beginning "Then, follow the first of the following options...." after the cases which apply only to "`classic`" and "`module`" scripts:
+  <dl>
+    <dt>If <a spec=html>the script's type</a> is "`speculationrules`"</dt>
+    <dd>
+      1. When <a spec=html>the script is ready</a>, run the following steps:
 
-<p class="issue">Adjust this consistent with the resolution of <a href="https://github.com/WICG/import-maps/issues/243">WICG/import-maps#243</a>.</p>
+        1. If [=the script's result=] is not null, [=list/append=] it to the element's [=node document=]'s [=document/list of speculation rule sets=].
+    </dd>
+  </dl>
+
+Inside the <a spec=html>execute a script block</a> algorithm:
 
 * Add the following case to the switch on <a spec=html>the script's type</a>:
   <dl>
@@ -133,10 +141,9 @@ Inside the <a spec=html>execute a script block</a> algorithm:
 
 <h3 id="speculation-rules-parsing">Parsing</h3>
 
-<div class="note">
+<p class="note">
   The general principle here is to allow the existence of directives which are not understood, but not to accept into the rule set a rule which the user agent does not fully understand.
   This reduces the risk of unintended activity by user agents which are unaware of most recently added directives which might limit the scope of a rule.
-</div>
 
 <div algorithm="parse speculation rules">
   To <dfn export>parse speculation rules</dfn> given a [=string=] |input| and a [=URL=] |baseURL|, perform the following steps. They return a [=speculation rule set=] or null.
@@ -174,26 +181,26 @@ Inside the <a spec=html>execute a script block</a> algorithm:
 
 <h3 id="speculation-rules-processing">Processing Model</h3>
 
+A [=document=] has a <dfn for=document export>list of speculation rule sets</dfn>, which is an initially empty [=list=].
+
 Periodically, the user agent may [=queue a task=] to the [=DOM manipulation task source=] to [=consider speculation=] for any [=document=].
 
-<div class="note">
+<p class="note">
   The user agent will likely do this after the insertion of new speculation rules, or when resources are idle and available.
-</div>
 
 <div algorithm="consider speculation">
   To <dfn export>consider speculation</dfn> for a [=document=] |document|:
 
-  1. For each <{script}> element [=connected=] to |document| where <a spec=html>the script's type</a> is "`speculationrules`" and [=the script's result=] is a [=speculation rule set=]:
-    1. [=list/For each=] |rule| of [=the script's result=]:
+  1. For each |ruleSet| of |document|'s [=document/list of speculation rule sets=]:
+    1. [=list/For each=] |rule| of |ruleSet|'s [=speculation rule set/prefetch rules=]:
       1. Let |requiresAnonymousClientIP| be true if |rule|'s [=speculation rule/requirements=] [=set/contains=] "`anonymous-client-ip`", and false otherwise.
-      1. [=list/For each=] |url| of |rule|'s [=speculation rule/URLs=]
+      1. [=list/For each=] |url| of |rule|'s [=speculation rule/URLs=]:
         1. The user agent MAY prefetch |url| given |requiresAnonymousClientIP|.
-           <div class="issue">TODO: expand this to actually elaborate on how prefetch works, once initiated, and to incorporate the |requiresAnonymousClientIP| flag.</div>
+           <p class="issue">TODO: expand this to actually elaborate on how prefetch works, once initiated, and to incorporate the |requiresAnonymousClientIP| flag.
 </div>
 
-<div class="issue">
+<p class="issue">
   We should also notice removals and consider cancelling speculated actions.
-</div>
 
 <h2 id="prerendering-bcs">Prerendering browsing contexts</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -128,7 +128,7 @@ Inside the [=prepare a script=] algorithm we make the following changes:
   <dl>
     <dt>"`speculationrules`"</dt>
     <dd>
-      1. Let |result| be the result of [=parse speculation rules|parsing speculation rules=] given source text and base URL.
+      1. Let |result| be the result of [=parsing speculation rules=] given source text and base URL.
 
       1. Set [=the script's result=] to |result|.
 
@@ -161,7 +161,7 @@ Inside the [=prepare a script=] algorithm we make the following changes:
   1. Let |result| be an empty [=speculation rule set=].
   1. If |parsed|["`prefetch`"] [=map/exists=] and is a [=list=], then [=list/for each=] |prefetchRule| of |parsed|["`prefetch`"]:
     1. If |prefetchRule| is not a [=map=], then [=iteration/continue=].
-    1. Let |rule| be the result of [=parse a speculation rule|parsing a speculation rule=] given |prefetchRule| and |baseURL|.
+    1. Let |rule| be the result of [=parsing a speculation rule=] given |prefetchRule| and |baseURL|.
     1. If |rule| is null, then [=iteration/continue=].
     1. [=list/Append=] |rule| to |result|'s [=speculation rule set/prefetch rules=].
   1. Return |result|.

--- a/index.bs
+++ b/index.bs
@@ -40,6 +40,8 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     urlPrefix: urls-and-fetching.html
       text: parse a URL; url: parse-a-url
       text: resulting URL record
+    urlPrefix: webappapis.html
+      text: script; url: concept-script
 </pre>
 
 <h2 id="link-rel-prerender">Link type "<dfn attr-value for="link/rel"><code>prerender</code></dfn>"</h2>
@@ -92,17 +94,32 @@ A <dfn>speculation rule set</dfn> is a [=struct=] with the following [=struct/it
 
 <em>Note</em>: This section contains modifications to the corresponding section of [[HTML]].
 
+To process speculation rules consistently with the existing script types, we make the following changes:
+
+* Add "`speculationrules`" to the list of valid values for <a spec=html>the script's type</a>.
+
+* Rename [=the script's script=] to <dfn>the script's result</dfn>, which can be either a <a spec="html">script</a> or a [=speculation rule set=].
+
+The following algorithms are updated accordingly:
+
+* [=Prepare a script=]: see [[#speculation-rules-prepare-a-script-patch]].
+* <a spec=html>Execute a script block</a>: Add the following case to the switch on <a spec=html>the script's type</a>:
+  <dl>
+    <dt>"`speculationrules`"</dt>
+    <dd>
+      1. [=Assert=]: Never reached.
+    </dd>
+  </dl>
+
 <p class="issue">We should consider whether we also want to make this execute even if scripting is disabled.</p>
 
 <p class="issue">We should also incorporate the case where a {{HTMLScriptElement/src}} attribute is set.</p>
 
 <p class="issue">We could fire {{HTMLElement/error}} and {{HTMLElement/load}} events if we wanted to.</p>
 
-Add "`speculationrules`" to the list of valid values for <a spec=html>the script's type</a>.
+<h3 id="speculation-rules-prepare-a-script-patch">Prepare a script</h3>
 
-Rename [=the script's script=] to <dfn>the script's result</dfn>, which can be either a script or a [=speculation rule set=].
-
-Inside the [=prepare a script=] algorithm:
+Inside the [=prepare a script=] algorithm we make the following changes:
 
 * Insert the following step as the second-last sub-step under "Determine the script's type as follows:":
   * If the script block's type string is an [=ASCII case-insensitive=] match for the string "`speculationrules`", <a spec=html>the script's type</a> is "`speculationrules`".
@@ -129,15 +146,6 @@ Inside the [=prepare a script=] algorithm:
     </dd>
   </dl>
 
-Inside the <a spec=html>execute a script block</a> algorithm:
-
-* Add the following case to the switch on <a spec=html>the script's type</a>:
-  <dl>
-    <dt>"`speculationrules`"</dt>
-    <dd>
-      1. [=Assert=]: Never reached.
-    </dd>
-  </dl>
 
 <h3 id="speculation-rules-parsing">Parsing</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -14,6 +14,7 @@ Boilerplate: omit conformance
 </pre>
 <pre class="link-defaults">
 spec:html; type:element; text:link
+spec:html; type:element; text:script
 </pre>
 <pre class="anchors">
 spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
@@ -74,6 +75,125 @@ A user agent must not <a spec=HTML>delay the load event</a> of the <{link}> elem
 
 <p class="issue">TODO: We should define a list of allowable referrer policies to prerender with, and early-return if the above referrer policy is not in this list.
 
+<h2 id="speculation-rules">Speculation rules</h2>
+
+<h3 id="speculation-rules-dfns">Definitions</h3>
+
+A <dfn>speculation rule</dfn> is a [=struct=] with the following [=struct/items=]:
+* <dfn for="speculation rule">URLs</dfn>, an [=ordered set=] of [=URLs=]
+* <dfn for="speculation rule">requirements</dfn>, an [=ordered set=] of [=strings=]
+
+The only valid string for [=speculation rule/requirements=] to contain is "`anonymous-client-ip`".
+
+A <dfn>speculation rule set</dfn> is a [=struct=] with the following [=struct/items=]:
+* <dfn for="speculation rule set">prefetch rules</dfn>, a [=list=] of [=speculation rules=]
+
+<h3 id="speculation-rules-script">The <{script}> element</h3>
+
+<em>Note</em>: This section contains modifications to the corresponding section of [[HTML]].
+
+<p class="issue">We should consider whether we also want to make this execute even if scripting is disabled.</p>
+
+<p class="issue">We should also incorporate the case where a {{HTMLScriptElement/src}} attribute is set.</p>
+
+<p class="issue">We could fire {{HTMLElement/error}} and {{HTMLElement/load}} events if we wanted to.</p>
+
+Add "`speculationrules`" to the list of valid values for <a spec=html>the script's type</a>.
+
+Rename [=the script's script=] to <dfn>the script's result</dfn>, which can be a [=speculation rule set=] in addition to any other valid type.
+
+Inside the [=prepare a script=] algorithm:
+
+* Insert the following step as the second-last sub-step under "Determine the script's type as follows:":
+  * If the script block's type string is an [=ASCII case-insensitive=] match for the string "`speculationrules`", <a spec=html>the script's type</a> is "`speculationrules`".
+
+* Insert the following case in the switch on <a spec=html>the script's type</a> within the step which begins "If the element does not have a {{HTMLScriptElement/src}} content attribute..."
+  <dl>
+    <dt>"`speculationrules`"</dt>
+    <dd>
+      1. Let |result| be the result of [=parse speculation rules|parsing speculation rules=] given source text and base URL.
+
+      1. If |result| is not null, set [=the script's result=] to |result|.
+
+      1. <a spec=html>The script is ready</a>.
+    </dd>
+  </dl>
+
+Inside the <a spec=html>execute a script block</a> algorithm:
+
+<p class="issue">Adjust this consistent with the resolution of <a href="https://github.com/WICG/import-maps/issues/243">WICG/import-maps#243</a>.</p>
+
+* Add the following case to the switch on <a spec=html>the script's type</a>:
+  <dl>
+    <dt>"`speculationrules`"</dt>
+    <dd>
+      1. [=Assert=]: Never reached.
+    </dd>
+  </dl>
+
+<h3 id="speculation-rules-parsing">Parsing</h3>
+
+<div class="note">
+  The general principle here is to allow the existence of directives which are not understood, but not to accept into the rule set a rule which the user agent does not fully understand.
+  This reduces the risk of unintended activity by user agents which are unaware of most recently added directives which might limit the scope of a rule.
+</div>
+
+<div algorithm="parse speculation rules">
+  To <dfn export>parse speculation rules</dfn> given a [=string=] |input| and a [=URL=] |baseURL|, perform the following steps. They return a [=speculation rule set=] or null.
+
+  1. Let |parsed| be the result of [=Parse JSON into Infra values|parsing JSON into Infra values=] given |input|.
+  1. If |parsed| is not a [=map=], then return null.
+  1. Let |result| be an empty [=speculation rule set=].
+  1. If |parsed|["`prefetch`"] [=map/exists=] and is a [=list=], then [=list/for each=] |prefetchRule| of |parsed|["`prefetch`"]:
+    1. If |prefetchRule| is not a [=map=], then [=iteration/continue=].
+    1. Let |rule| be the result of [=parse a speculation rule|parsing a speculation rule=] given |prefetchRule| and |baseURL|.
+    1. If |rule| is null, then [=iteration/continue=].
+    1. [=list/Append=] |rule| to |result|'s [=speculation rule set/prefetch rules=].
+  1. Return |result|.
+</div>
+
+<div algorithm="parse a speculation rule">
+  To <dfn export>parse a speculation rule</dfn> given a [=map=] |input| and a [=URL=] |baseURL|, perform the following steps. They return a [=speculation rule=] or null.
+
+  1. If |input| has any [=map/key=] other than "`source`", "`urls`", and "`requires`", then return null.
+  1. If |input|["`source`"] does not [=map/exist=] or is not the [=string=] "`list`", then return null.
+  1. Let |urls| be an empty [=list=].
+  1. If |input|["`urls`"] does not [=map/exist=], is not a [=list=], or has any element which is not a [=string=], then return null.
+  1. [=list/For each=] |urlString| of |input|["`urls`"]:
+    1. Let |parsedURL| be the result of [=basic URL parser|parsing=] |urlString| with |baseURL|.
+    1. If |parsedURL| is failure, then [=iteration/continue=].
+    1. If |parsedURL|'s [=url/scheme=] is not an [=HTTP(S) scheme=], then [=iteration/continue=].
+    1. [=list/Append=] |parsedURL| to |urls|.
+  1. Let |requirements| be an empty [=ordered set=].
+  1. If |input|["`requires`"] [=map/exists=], but is not a [=list=], then return null.
+  1. [=list/For each=] |requirement| of |input|["`requires`"]:
+    1. If |requirement| is not the [=string=] "`anonymous-client-ip`", then return null.
+    1. [=set/Append=] |requirement| to |requirements|.
+  1. Return a [=speculation rule=] with [=speculation rule/URLs=] |urls| and [=speculation rule/requirements=] |requirements|.
+</div>
+
+<h3 id="speculation-rules-processing">Processing Model</h3>
+
+Periodically, the user agent may [=queue a task=] to the [=DOM manipulation task source=] to [=consider speculation=] for any [=document=].
+
+<div class="note">
+  The user agent will likely do this after the insertion of new speculation rules, or when resources are idle and available.
+</div>
+
+<div algorithm="consider speculation">
+  To <dfn export>consider speculation</dfn> for a [=document=] |document|:
+
+  1. For each <{script}> element [=connected=] to |document| where <a spec=html>the script's type</a> is "`speculationrules`" and [=the script's result=] is a [=speculation rule set=]:
+    1. [=list/For each=] |rule| of [=the script's result=]:
+      1. Let |requiresAnonymousClientIP| be true if |rule|'s [=speculation rule/requirements=] [=set/contains=] "`anonymous-client-ip`", and false otherwise.
+      1. [=list/For each=] |url| of |rule|'s [=speculation rule/URLs=]
+        1. The user agent MAY prefetch |url| given |requiresAnonymousClientIP|.
+           <div class="issue">TODO: expand this to actually elaborate on how prefetch works, once initiated, and to incorporate the |requiresAnonymousClientIP| flag.</div>
+</div>
+
+<div class="issue">
+  We should also notice removals and consider cancelling speculated actions.
+</div>
 
 <h2 id="prerendering-bcs">Prerendering browsing contexts</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -69,7 +69,7 @@ The appropriate times to <a spec=HTML>fetch and process the linked resource</a> 
   1. [=Create a prerendering browsing context=] with |url|, |referrer policy|, and |el|'s [=Node/node document=].
 </div>
 
-A user agent must not <a spec=HTML>delay the load event</a> of the <{link}> element's <a for=Node>node document</a> for this link type.
+A user agent must not <a spec=HTML>delay the load event</a> of the <{link}> element's [=Node/node document=] for this link type.
 
 <p class="note">Note that this link type does not fire {{HTMLElement/error}} or {{HTMLElement/load}} events, unlike many other link types that create <a spec=HTML>external resource links</a>.
 
@@ -125,7 +125,7 @@ Inside the [=prepare a script=] algorithm:
     <dd>
       1. When <a spec=html>the script is ready</a>, run the following steps:
 
-        1. If [=the script's result=] is not null, [=list/append=] it to the element's [=node document=]'s [=document/list of speculation rule sets=].
+        1. If [=the script's result=] is not null, [=list/append=] it to the element's [=Node/node document=]'s [=document/list of speculation rule sets=].
     </dd>
   </dl>
 
@@ -183,7 +183,8 @@ Inside the <a spec=html>execute a script block</a> algorithm:
 
 A [=document=] has a <dfn for=document export>list of speculation rule sets</dfn>, which is an initially empty [=list=].
 
-Periodically, the user agent may [=queue a task=] to the [=DOM manipulation task source=] to [=consider speculation=] for any [=document=].
+<!-- TODO(domfarolino): Get rid of the `data-link-type="interface"` once we fix the dfn in HTML. -->
+Periodically, the user agent may [=queue a task=] to the <a data-link-type="interface">DOM manipulation task source</a> to [=consider speculation=] for any [=document=].
 
 <p class="note">
   The user agent will likely do this after the insertion of new speculation rules, or when resources are idle and available.


### PR DESCRIPTION
This is a draft of a minimal version of the speculation rules proposal, which covers only how to trigger prefetching with an optional "requires anonymous client IP" flag for a fixed list of URLs.

I think the bulk of the complexity is in the stuff that's independent of trigger, i.e. "what does it mean to prefetch".

@domenic @domfarolino @mfalken does this seem reasonable?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jeremyroman/alternate-loading-modes/pull/24.html" title="Last updated on Jan 26, 2021, 7:44 PM UTC (954fba6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/jeremyroman/alternate-loading-modes/24/9aebf57...954fba6.html" title="Last updated on Jan 26, 2021, 7:44 PM UTC (954fba6)">Diff</a>