### PR TITLE
Expand speculation rules to include prefetch-with-subresources.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -89,6 +89,7 @@ The only valid string for [=speculation rule/requirements=] to contain is "`anon
 
 A <dfn>speculation rule set</dfn> is a [=struct=] with the following [=struct/items=]:
 * <dfn for="speculation rule set">prefetch rules</dfn>, a [=list=] of [=speculation rules=]
+* <dfn for="speculation rule set">prefetch-with-subresources rules</dfn>, a [=list=] of [=speculation rules=]
 
 <h3 id="speculation-rules-script">The <{script}> element</h3>
 
@@ -164,6 +165,11 @@ Inside the [=prepare a script=] algorithm we make the following changes:
     1. Let |rule| be the result of [=parsing a speculation rule=] given |prefetchRule| and |baseURL|.
     1. If |rule| is null, then [=iteration/continue=].
     1. [=list/Append=] |rule| to |result|'s [=speculation rule set/prefetch rules=].
+  1. If |parsed|["`prefetch_with_subresources`"] [=map/exists=] and is a [=list=], then [=list/for each=] |pwsRule| of |parsed|["`prefetch_with_subresources`"]:
+    1. If |pwsRule| is not a [=map=], then [=iteration/continue=].
+    1. Let |rule| be the result of [=parsing a speculation rule=] given |pwsRule| and |baseURL|.
+    1. If |rule| is null, then [=iteration/continue=].
+    1. [=list/Append=] |rule| to |result|'s [=speculation rule set/prefetch-with-subresources rules=].
   1. Return |result|.
 </div>
 
@@ -203,6 +209,11 @@ Periodically, for any [=document=] |document|, the user agent may [=queue a glob
   1. If |document| is not [=Document/fully active=], then return.
      <p class="issue">It's likely that we should also handle prerendered and back-forward cached documents.
   1. For each |ruleSet| of |document|'s [=document/list of speculation rule sets=]:
+    1. [=list/For each=] |rule| of |ruleSet|'s [=speculation rule set/prefetch-with-subresources rules=]:
+      1. Let |requiresAnonymousClientIP| be true if |rule|'s [=speculation rule/requirements=] [=set/contains=] "`anonymous-client-ip`", and false otherwise.
+      1. [=list/For each=] |url| of |rule|'s [=speculation rule/URLs=]:
+        1. The user agent may prefetch |url| given |requiresAnonymousClientIP|, including subresources identified by <a href="https://github.com/whatwg/html/pull/5959">speculative HTML parsing</a>.
+           <p class="issue">TODO: expand this along with prefetch more generally.
     1. [=list/For each=] |rule| of |ruleSet|'s [=speculation rule set/prefetch rules=]:
       1. Let |requiresAnonymousClientIP| be true if |rule|'s [=speculation rule/requirements=] [=set/contains=] "`anonymous-client-ip`", and false otherwise.
       1. [=list/For each=] |url| of |rule|'s [=speculation rule/URLs=]:

--- a/triggers.md
+++ b/triggers.md
@@ -40,8 +40,7 @@ The following example illustrates the basic idea:
 }
 </script>
 ```
-
-The rules are divided into sections by the action, such as "dns-prefetch", "preconnect", "prefetch" or "prerender", that they authorize. A user agent may always choose to stop early, for instance by prefetching where prerendering was permitted.
+The rules are divided into sections by the action, such as "dns-prefetch", "preconnect", "prefetch", "prefetch\_with\_subresources" or "prerender", that they authorize. A user agent may always choose to stop early, for instance by prefetching where prerendering was permitted.
 
 Since these are rules for optional behavior (the UA is always free not to speculate), parsing of these can be somewhat conservative. If a UA sees a rule it does not understand, that rule is discarded. Because a rule always authorizes additional speculation (but does not confine speculation allowed by other rules), discarding rules never authorizes more speculation than the author intended, only less.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jeremyroman/alternate-loading-modes/pull/28.html" title="Last updated on Jan 29, 2021, 4:17 PM UTC (e6472b1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/jeremyroman/alternate-loading-modes/28/a7d6680...e6472b1.html" title="Last updated on Jan 29, 2021, 4:17 PM UTC (e6472b1)">Diff</a>