### PR TITLE
Rename anonymous-client-ip to anonymous-client-ip-when-cross-origin.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -85,7 +85,7 @@ A <dfn>speculation rule</dfn> is a [=struct=] with the following [=struct/items=
 * <dfn for="speculation rule">URLs</dfn>, an [=ordered set=] of [=URLs=]
 * <dfn for="speculation rule">requirements</dfn>, an [=ordered set=] of [=strings=]
 
-The only valid string for [=speculation rule/requirements=] to contain is "`anonymous-client-ip`".
+The only valid string for [=speculation rule/requirements=] to contain is "`anonymous-client-ip-when-cross-origin`".
 
 A <dfn>speculation rule set</dfn> is a [=struct=] with the following [=struct/items=]:
 * <dfn for="speculation rule set">prefetch rules</dfn>, a [=list=] of [=speculation rules=]
@@ -182,7 +182,7 @@ Inside the [=prepare a script=] algorithm we make the following changes:
   1. Let |requirements| be an empty [=ordered set=].
   1. If |input|["`requires`"] [=map/exists=], but is not a [=list=], then return null.
   1. [=list/For each=] |requirement| of |input|["`requires`"]:
-    1. If |requirement| is not the [=string=] "`anonymous-client-ip`", then return null.
+    1. If |requirement| is not the [=string=] "`anonymous-client-ip-when-cross-origin`", then return null.
     1. [=set/Append=] |requirement| to |requirements|.
   1. Return a [=speculation rule=] with [=speculation rule/URLs=] |urls| and [=speculation rule/requirements=] |requirements|.
 </div>
@@ -204,10 +204,10 @@ Periodically, for any [=document=] |document|, the user agent may [=queue a glob
      <p class="issue">It's likely that we should also handle prerendered and back-forward cached documents.
   1. For each |ruleSet| of |document|'s [=document/list of speculation rule sets=]:
     1. [=list/For each=] |rule| of |ruleSet|'s [=speculation rule set/prefetch rules=]:
-      1. Let |requiresAnonymousClientIP| be true if |rule|'s [=speculation rule/requirements=] [=set/contains=] "`anonymous-client-ip`", and false otherwise.
+      1. Let |requiresAnonymousClientIPWhenCrossOrigin| be true if |rule|'s [=speculation rule/requirements=] [=set/contains=] "`anonymous-client-ip-when-cross-origin`", and false otherwise.
       1. [=list/For each=] |url| of |rule|'s [=speculation rule/URLs=]:
-        1. The user agent may prefetch |url| given |requiresAnonymousClientIP|.
-           <p class="issue">TODO: expand this to actually elaborate on how prefetch works, once initiated, and to incorporate the |requiresAnonymousClientIP| flag. We may wish to include language about when the UA should deduplicate requests.
+        1. The user agent may prefetch |url| given |requiresAnonymousClientIPWhenCrossOrigin|.
+           <p class="issue">TODO: expand this to actually elaborate on how prefetch works, once initiated, and to incorporate the |requiresAnonymousClientIPWhenCrossOrigin| flag. We may wish to include language about when the UA should deduplicate requests.
 </div>
 
 <p class="issue">

--- a/triggers.md
+++ b/triggers.md
@@ -85,13 +85,13 @@ The link element itself can also be [matched][selector-match] using [CSS selecto
 
 This feature is designed to allow future extension, such as a notion of requirements: assertions in rules about the capabilities of the user agent while executing them. Since user agents disregard rules they do not understand, this can be safely added later on without violating the requirements listed.
 
-For example, an "anonymous-client-ip" requirement might mean that the rule matches only if the user agent can prevent the client IP address from being visible to the origin server.
+For example, an "anonymous-client-ip-when-cross-origin" requirement might mean that the rule matches only if the user agent can prevent the client IP address from being visible to the origin server if a cross-origin request is issued.
 
 ```json
 {"prerender": [
   {"source": "document",
    "if_selector_matches": [".user-generated"],
-   "requires": ["anonymous-client-ip"]}
+   "requires": ["anonymous-client-ip-when-cross-origin"]}
 ]}
 ```
 This would be defined to discard any rules with requirements that are not recognized or are not supported in the current configuration. Due to the conservative parsing rules, any UA which did not support requirements at all would discard all rules with requirements.


### PR DESCRIPTION
It's a bit of a mouthful but it sounded like this was what people were leaning toward. It's explicit and kinda analogous to referrer policy's "strict origin when cross origin".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jeremyroman/alternate-loading-modes/pull/29.html" title="Last updated on Jan 29, 2021, 7:06 PM UTC (ebe21ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/jeremyroman/alternate-loading-modes/29/9c25d02...ebe21ce.html" title="Last updated on Jan 29, 2021, 7:06 PM UTC (ebe21ce)">Diff</a>