### PR TITLE
Basic prerendering redirect handling

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -377,8 +377,7 @@ Patch the redirect-handling portion of the [=process a navigate fetch=] algorith
 
     1. Set |browsingContext|'s [=browsing context/loading mode=] to "`uncredentialed-prerender`".
 
-<!-- TODO(domfarolino): This should not be var ignore, but instead should reference the actual variable once the PR that introduces it lands -->
-    1. If the <var ignore>list of sufficiently-strict referrer policies</var> does not [=list/contain=] <var ignore>request</var>'s [=referrer policy=], then:
+    1. If the [=list of sufficiently-strict speculative navigation referrer policies=] does not [=list/contain=] <var ignore>request</var>'s [=referrer policy=], then:
 
       1. [=Assert=]: |response| is not null.
 

--- a/index.bs
+++ b/index.bs
@@ -366,6 +366,29 @@ Patch the [=navigate=] algorithm to allow the [=prerendering browsing context/ac
       1. Return.
 </div>
 
+<h3 id="redirect-handling">Redirect handling</h3>
+
+Patch the redirect-handling portion of the [=process a navigate fetch=] algorithm to update certain properties of a [=prerendering browsing context=] upon cross-origin redirects as follows:
+
+<div algorithm="navigate activate patch redirect handling">
+  In [=process a navigate fetch=], append the following steps after the step 9 sub-step 1, in order to handle redirects correctly;
+
+  1. If |browsingContext| is a [=prerendering browsing context=]  and <var ignore>currentURL</var> is not [=same origin=] with <var ignore>incumbentNavigationOrigin</var>, then:
+
+    1. Set |browsingContext|'s [=browsing context/loading mode=] to `uncredentialed-prerender`.
+
+<!-- TODO(domfarolino): This should not be var ignore, but instead should reference the actual variable once the PR that introduces it lands -->
+    1. If the <var ignore>list of sufficiently-strict referrer policies</var> does not [=list/contain=] <var ignore>request</var>'s [=referrer policy=], then:
+
+      1. [=Assert=]: |response| is not null.
+
+      1. [=Assert=]: |response|'s [=response/location URL=] is a [=URL=] whose [=url/scheme=] is a [=HTTP(S) scheme=].
+
+      1. Set |response| to a [=network error=] and [=iteration/break=].
+
+<p class="issue">As per recent conversation about <a href="https://github.com/jeremyroman/alternate-loading-modes/issues/17">Issue 17</a>, we should support activating a prerender during a navigation redirect.
+</div>
+
 <h3 id="always-replacement">Maintaining a trivial session history</h3>
 
 <div algorithm="navigate historyHandling patch">

--- a/index.bs
+++ b/index.bs
@@ -373,7 +373,7 @@ Patch the redirect-handling portion of the [=process a navigate fetch=] algorith
 <div algorithm="navigate activate patch redirect handling">
   In [=process a navigate fetch=], append the following steps after the first sub-step under "While true:" in order to handle redirects correctly;
 
-  1. If |browsingContext| is a [=prerendering browsing context=]  and <var ignore>currentURL</var> is not [=same origin=] with <var ignore>incumbentNavigationOrigin</var>, then:
+  1. If |browsingContext| is a [=prerendering browsing context=]  and <var ignore>currentURL</var>'s [=url/origin=] is not [=same origin=] with <var ignore>incumbentNavigationOrigin</var>, then:
 
     1. Set |browsingContext|'s [=browsing context/loading mode=] to `uncredentialed-prerender`.
 

--- a/index.bs
+++ b/index.bs
@@ -371,7 +371,7 @@ Patch the [=navigate=] algorithm to allow the [=prerendering browsing context/ac
 Patch the redirect-handling portion of the [=process a navigate fetch=] algorithm to update certain properties of a [=prerendering browsing context=] upon cross-origin redirects as follows:
 
 <div algorithm="navigate activate patch redirect handling">
-  In [=process a navigate fetch=], append the following steps after the step 9 sub-step 1, in order to handle redirects correctly;
+  In [=process a navigate fetch=], append the following steps after the first sub-step under "While true:" in order to handle redirects correctly;
 
   1. If |browsingContext| is a [=prerendering browsing context=]  and <var ignore>currentURL</var> is not [=same origin=] with <var ignore>incumbentNavigationOrigin</var>, then:
 
@@ -386,7 +386,7 @@ Patch the redirect-handling portion of the [=process a navigate fetch=] algorith
 
       1. Set |response| to a [=network error=] and [=iteration/break=].
 
-<p class="issue">As per recent conversation about <a href="https://github.com/jeremyroman/alternate-loading-modes/issues/17">Issue 17</a>, we should support activating a prerender during a navigation redirect.
+<p class="issue">As per recent conversation about <a href="https://github.com/jeremyroman/alternate-loading-modes/issues/17">Issue 17</a>, we should also support activating a prerender during a navigation redirect.
 </div>
 
 <h3 id="always-replacement">Maintaining a trivial session history</h3>

--- a/index.bs
+++ b/index.bs
@@ -375,7 +375,7 @@ Patch the redirect-handling portion of the [=process a navigate fetch=] algorith
 
   1. If |browsingContext| is a [=prerendering browsing context=]  and <var ignore>currentURL</var>'s [=url/origin=] is not [=same origin=] with <var ignore>incumbentNavigationOrigin</var>, then:
 
-    1. Set |browsingContext|'s [=browsing context/loading mode=] to `uncredentialed-prerender`.
+    1. Set |browsingContext|'s [=browsing context/loading mode=] to "`uncredentialed-prerender`".
 
 <!-- TODO(domfarolino): This should not be var ignore, but instead should reference the actual variable once the PR that introduces it lands -->
     1. If the <var ignore>list of sufficiently-strict referrer policies</var> does not [=list/contain=] <var ignore>request</var>'s [=referrer policy=], then:


### PR DESCRIPTION
This PR depends on https://github.com/jeremyroman/alternate-loading-modes/pull/33.

This PR patches the [process a navigate fetch](https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch) algorithm's redirect handling to support two things:
 - Setting a prerendering browsing context's loading mode to "uncredentialed prerender" in the case that it redirects cross-origin
 - Cancelling a prerender request in the case that a cross-origin redirect sets an insufficiently-strict referrer policy
    - This seems good for consistency with prerender matching, though it should be noted it doesn't have an impact on referrer redaction. Once a sufficiently-strict referrer policy is applied, then no referrer policy applied by any redirects can loosen or expand the amount of referrer information exposed. That being said, I'm open to removing this, but I think it is nice for matching and general consistency.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jeremyroman/alternate-loading-modes/pull/34.html" title="Last updated on Feb 2, 2021, 11:07 PM UTC (4733265)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/jeremyroman/alternate-loading-modes/34/b3b8f35...4733265.html" title="Last updated on Feb 2, 2021, 11:07 PM UTC (4733265)">Diff</a>