### PR TITLE
Allow for the activation of a prerendering browsing context upon navigation redirect

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -343,19 +343,16 @@ The <dfn attribute for="Document">onprerenderingchange</dfn> attribute is an [=e
 <h3 id="navigate-activation">Allowing activation in place of navigation</h3>
 
 <div algorithm="can activate a prerender">
-  The <dfn>can activate a prerender</dfn> algorithm takes a [=browsing context=] |browsingContext|, a [=history handling behavior=] |historyHandling|, a string |navigationType|, and a [=request=] |request|, and runs the following steps:
+  We <dfn>can activate a prerender</dfn> given a [=browsing context=] |browsingContext|, a [=history handling behavior=] |historyHandling|, a string |navigationType|, and a [=request=] |request|, if the following steps return true:
 
-  1. If all of the following are true:
+  1. Return true if all of the following are true:
 
       * |browsingContext| is a [=top-level browsing context=]
+      * |browsingContext| is not a [=prerendering browsing context=]
       * |historyHandling| is "`default`" or "`replace`"
       * |navigationType| is "`other`"
       * |request|'s [=request/method=] is \``GET`\`
       * |browsingContext|'s [=active document=]'s [=Document/prerendering browsing contexts map=][(|request|'s [=request/URL=], |request|'s [=request/referrer policy=])] [=map/exists=] and is not [=prerendering browsing context/empty=]
-
-    then:
-
-    1. Return true.
 
   1. Otherwise, return false.
 
@@ -366,7 +363,7 @@ Patch the [=navigate=] algorithm to allow the [=prerendering browsing context/ac
 <div algorithm="navigate activate patch">
   In [=navigate=], append the following steps after the fragment navigation handling (currently step 6):
 
-  1. If |resource| is a [=request=] and [=can activate a prerender=] given |browsingContext|, |historyHandling|, <var ignore>navigationType</var>, and |resource| returns true, then:
+  1. If |resource| is a [=request=] and we [=can activate a prerender=] given |browsingContext|, |historyHandling|, <var ignore>navigationType</var>, and |resource|, then:
 
     1. [=prerendering browsing context/Activate=] <var ignore>successorBC</var> in place of |browsingContext| given |historyHandling|.
 
@@ -386,7 +383,7 @@ Patch the [=process a navigate fetch=] algorithm like so:
 <div algorithm="navigate activate patch redirect handling">
   In [=process a navigate fetch=], append the following steps after the first sub-step under "While true:" in order to handle redirects correctly:
 
-  1. If |browsingContext| is not a [=prerendering browsing context=] and [=can activate a prerender=] given |browsingContext| |historyHandling|, <var ignore>navigationType</var>, and <var ignore>request</var> returns true, then:
+  1. If we [=can activate a prerender=] given |browsingContext|, |historyHandling|, <var ignore>navigationType</var>, and <var ignore>request</var>, then:
 
     1. [=prerendering browsing context/Activate=] |browsingContext| in place of <var ignore>sourceBrowsingContext</var> given |historyHandling|.
 

--- a/index.bs
+++ b/index.bs
@@ -381,7 +381,7 @@ This section contains two types of changes to the navigation redirect handling p
  * Logic allowing navigation redirects that are not inside of a [=prerendering browsing context=] to [=prerendering browsing context/activate=] a [=prerendering browsing context=].
  * Logic that updates specific state of a [=prerendering browsing context=] when it redirects coss-origin.
 
-Patch the redirect-handling portion of the [=process a navigate fetch=] algorithm like so:
+Patch the [=process a navigate fetch=] algorithm like so:
 
 <div algorithm="navigate activate patch redirect handling">
   In [=process a navigate fetch=], append the following steps after the first sub-step under "While true:" in order to handle redirects correctly:
@@ -403,8 +403,6 @@ Patch the redirect-handling portion of the [=process a navigate fetch=] algorith
       1. [=Assert=]: |response|'s [=response/location URL=] is a [=URL=] whose [=url/scheme=] is a [=HTTP(S) scheme=].
 
       1. Set |response| to a [=network error=] and [=iteration/break=].
-
-<p class="issue">As per recent conversation about <a href="https://github.com/jeremyroman/alternate-loading-modes/issues/17">Issue 17</a>, we should also support activating a prerender during a navigation redirect.
 </div>
 
 <h3 id="always-replacement">Maintaining a trivial session history</h3>

--- a/index.bs
+++ b/index.bs
@@ -344,34 +344,53 @@ The <dfn attribute for="Document">onprerenderingchange</dfn> attribute is an [=e
 
 Patch the [=navigate=] algorithm to allow the [=prerendering browsing context/activate|activation=] of a [=prerendering browsing context=] in place of a normal navigation as follows:
 
-<div algorithm="navigate activate patch">
-  In [=navigate=], append the following steps after the fragment navigation handling (currently step 6):
+<div algorithm="can activate a prerender">
+  The <dfn>can activate a prerender</dfn> algorithm takes in a [=browsing context=] |browsingContext|, a [=history handling behavior=] |historyHandling|, a string |navigationType|, and a [=request=] |request| is as follows:
 
   1. If all of the following are true:
 
       * |browsingContext| is a [=top-level browsing context=]
       * |historyHandling| is "`default`" or "`replace`"
-      * <var ignore>navigationType</var> is "`other`"
-      * |resource| is a [=request=] whose [=request/method=] is \``GET`\`
-      * |browsingContext|'s [=active document=]'s [=Document/prerendering browsing contexts map=][(|resource|'s [=request/URL=], |resource|'s [=request/referrer policy=])] [=map/exists=]
+      * |navigationType| is "`other`"
+      * |request|'s [=request/method=] is \``GET`\`
+      * |browsingContext|'s [=active document=]'s [=Document/prerendering browsing contexts map=][(|request|'s [=request/URL=], |request|'s [=request/referrer policy=])] [=map/exists=] and is not [=prerendering browsing context/empty=]
 
     then:
 
-    1. Let |successorBC| be |browsingContext|'s [=active document=]'s [=Document/prerendering browsing contexts map=][(|resource|'s [=request/URL=], |resource|'s [=request/referrer policy=])].
+    1. Return true.
 
-    1. If |successorBC| is not [=prerendering browsing context/empty=], then:
+  1. Otherwise, return false.
 
-      1. [=prerendering browsing context/Activate=] |successorBC| in place of |browsingContext| given |historyHandling|.
-
-      1. Return.
 </div>
+
+<div algorithm="navigate activate patch">
+  In [=navigate=], append the following steps after the fragment navigation handling (currently step 6):
+
+  1. If |resource| is a [=request=] and [=can activate a prerender=] given |browsingContext|, |historyHandling|, <var ignore>navigationType</var>, and |resource| returns true, then:
+
+    1. [=prerendering browsing context/Activate=] <var ignore>successorBC</var> in place of |browsingContext| given |historyHandling|.
+
+    1. Return.
+</div>
+
+Navigation redirects can also [=prerendering browsing context/activate=] [=prerendering browsing contexts=]. This is defined in the [[#redirect-handling]] section.
 
 <h3 id="redirect-handling">Redirect handling</h3>
 
-Patch the redirect-handling portion of the [=process a navigate fetch=] algorithm to update certain properties of a [=prerendering browsing context=] upon cross-origin redirects as follows:
+This section contains two types of changes to the navigation redirect handling portion of the [=process a navigate fetch=] algorithm:
+ * Logic allowing navigation redirects that are not inside of a [=prerendering browsing context=] to [=prerendering browsing context/activate=] a [=prerendering browsing context=].
+ * Logic that updates specific state of a [=prerendering browsing context=] when it redirects coss-origin.
+
+Patch the redirect-handling portion of the [=process a navigate fetch=] algorithm like so:
 
 <div algorithm="navigate activate patch redirect handling">
-  In [=process a navigate fetch=], append the following steps after the first sub-step under "While true:" in order to handle redirects correctly;
+  In [=process a navigate fetch=], append the following steps after the first sub-step under "While true:" in order to handle redirects correctly:
+
+  1. If |browsingContext| is not a [=prerendering browsing context=] and [=can activate a prerender=] given |browsingContext| |historyHandling|, <var ignore>navigationType</var>, and <var ignore>request</var> returns true, then:
+
+    1. [=prerendering browsing context/Activate=] |browsingContext| in place of <var ignore>sourceBrowsingContext</var> given |historyHandling|.
+
+    1. Return.
 
   1. If |browsingContext| is a [=prerendering browsing context=]  and <var ignore>currentURL</var>'s [=url/origin=] is not [=same origin=] with <var ignore>incumbentNavigationOrigin</var>, then:
 

--- a/index.bs
+++ b/index.bs
@@ -342,10 +342,8 @@ The <dfn attribute for="Document">onprerenderingchange</dfn> attribute is an [=e
 
 <h3 id="navigate-activation">Allowing activation in place of navigation</h3>
 
-Patch the [=navigate=] algorithm to allow the [=prerendering browsing context/activate|activation=] of a [=prerendering browsing context=] in place of a normal navigation as follows:
-
 <div algorithm="can activate a prerender">
-  The <dfn>can activate a prerender</dfn> algorithm takes in a [=browsing context=] |browsingContext|, a [=history handling behavior=] |historyHandling|, a string |navigationType|, and a [=request=] |request| is as follows:
+  The <dfn>can activate a prerender</dfn> algorithm takes a [=browsing context=] |browsingContext|, a [=history handling behavior=] |historyHandling|, a string |navigationType|, and a [=request=] |request|, and runs the following steps:
 
   1. If all of the following are true:
 
@@ -362,6 +360,8 @@ Patch the [=navigate=] algorithm to allow the [=prerendering browsing context/ac
   1. Otherwise, return false.
 
 </div>
+
+Patch the [=navigate=] algorithm to allow the [=prerendering browsing context/activate|activation=] of a [=prerendering browsing context=] in place of a normal navigation as follows:
 
 <div algorithm="navigate activate patch">
   In [=navigate=], append the following steps after the fragment navigation handling (currently step 6):


### PR DESCRIPTION
This PR:
 - Consolidates the conditions that are checked before activating a prerender to `<dfn>can activate a prerender</dfn>` which returns a true/false result as to whether or not we can activate a prerendering browsing context
 - Invokes these steps in two places: (1) In normal #navigate, like we do now, (2) In #process-a-navigate-fetch for redirect handling of non-prerendering navigations
    - I wrote the spec in such a way where only navigation redirects in non-prerendering-browsing-contexts can activate prerendering browsing contexts. This raises the more general question: should we let prerenders activate other prerenders /cc @jeremyroman. We should probably answer this question before landing this PR (see the review I left below)

Closes #17. /cc @mfalken


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jeremyroman/alternate-loading-modes/pull/35.html" title="Last updated on Feb 5, 2021, 5:46 PM UTC (d603169)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/jeremyroman/alternate-loading-modes/35/fa427e0...d603169.html" title="Last updated on Feb 5, 2021, 5:46 PM UTC (d603169)">Diff</a>