### PR TITLE
prompt()'s "soft block" return value should be null

### DIFF
--- a/browsing-context.md
+++ b/browsing-context.md
@@ -140,7 +140,7 @@ Apart from the privacy-related restrictions to communications and storage, while
 
 - `window.alert()` and `window.print()` will silently do nothing pre-activation.
 
-- `window.confirm()` and `window.prompt()` will silently return their default values (`false` and `""`) pre-activation.
+- `window.confirm()` and `window.prompt()` will silently return their default values (`false` and `null`) pre-activation.
 
 _Note: specifying this will likely be messy, as these different APIs are controlled through different mechanisms, and many specs will need to be patched to include a "pause until activation" step._
 


### PR DESCRIPTION
Per https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-prompt

Credit to https://chromium-review.googlesource.com/c/chromium/src/+/2927630