### PR TITLE
Add prerender security/privacy considerations that link to other specs

### DIFF
--- a/prefetch.bs
+++ b/prefetch.bs
@@ -776,6 +776,10 @@ The following parameters are defined for the "`prefetch`" token:
 
 See <a href="speculation-rules.html#security-considerations">Security considerations (Speculation Rules)</a>.
 
+For the integration of this spec with No-Vary-Search, see <a href="no-vary-search.html#security-considerations">No-Vary-Search Security considerations</a>.
+
 <h2 id="privacy-considerations">Privacy considerations</h2>
 
 See <a href="speculation-rules.html#privacy-considerations">Privacy considerations (Speculation Rules)</a>.
+
+For the integration of this spec with No-Vary-Search, see <a href="no-vary-search.html#privacy-considerations">No-Vary-Search Privacy considerations</a>.

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -1033,7 +1033,7 @@ See <a href="speculation-rules.html#security-considerations">Security considerat
 
 For the integration of this spec with No-Vary-Search, see <a href="no-vary-search.html#security-considerations">No-Vary-Search Security considerations</a>.
 
-<p class="issue">Add security considerations that are specific to prerendering.</p>
+<p class="issue">Add security considerations that are specific to prerendering. See <a href="https://github.com/WICG/nav-speculation/issues/319">issue #319</a>.</p>
 
 <h2 id="privacy-considerations">Privacy considerations</h2>
 
@@ -1041,4 +1041,4 @@ See <a href="speculation-rules.html#privacy-considerations">Privacy consideratio
 
 For the integration of this spec with No-Vary-Search, see <a href="no-vary-search.html#privacy-considerations">No-Vary-Search Privacy considerations</a>.
 
-<p class="issue">Add privacy considerations that are specific to prerendering.</p>
+<p class="issue">Add privacy considerations that are specific to prerendering. See <a href="https://github.com/WICG/nav-speculation/issues/319">issue #319</a>.</p>

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -1026,3 +1026,19 @@ APIs that require the "<code>visible</code>" [=Document/visibility state=]:
 
 More complicated cases:
 - [=Request Picture-in-Picture=] as invoked due to {{HTMLVideoElement/requestPictureInPicture()|video.requestPictureInPicture()}} requires either [=transient activation=], or the [=Document/visibility state=] to have been "<code>visible</code>". [[PICTURE-IN-PICTURE]]
+
+<h2 id="security-considerations">Security considerations</h2>
+
+See <a href="speculation-rules.html#security-considerations">Security considerations (Speculation Rules)</a>.
+
+For the integration of this spec with No-Vary-Search, see <a href="no-vary-search.html#security-considerations">No-Vary-Search Security considerations</a>.
+
+<p class="issue">Add security considerations that are specific to prerendering.</p>
+
+<h2 id="privacy-considerations">Privacy considerations</h2>
+
+See <a href="speculation-rules.html#privacy-considerations">Privacy considerations (Speculation Rules)</a>.
+
+For the integration of this spec with No-Vary-Search, see <a href="no-vary-search.html#privacy-considerations">No-Vary-Search Privacy considerations</a>.
+
+<p class="issue">Add privacy considerations that are specific to prerendering.</p>


### PR DESCRIPTION
This gets started with security and privacy considerations for prerendering by linking to existing considerations for the specs this integrates with.
    
Note that considerations specific to prerendering still need to be added.
