### PR TITLE
Remove spec for Supports-Loading-Mode: uncredentialed-prefetch

### DIFF
--- a/opt-in.md
+++ b/opt-in.md
@@ -31,10 +31,10 @@ Supports-Loading-Mode: uncredentialed-prefetch, uncredentialed-prerender
 
 This is an [HTTP structured header][http-structured-header] which lists tokens indicating the loading modes the content is ready for. The tokens we so far envision are:
 
-* `uncredentialed-prefetch`
-* `uncredentialed-prerender`
-* `credentialed-prerender`
-* `prerender-cross-origin-iframes`
+* `uncredentialed-prefetch` (future idea)
+* `uncredentialed-prerender` (future idea)
+* `credentialed-prerender` (specced and implemented; see [explainer](./prerendering-same-site.md))
+* `prerender-cross-origin-iframes` (specced and implemented; see [explainer](./prerendering-cross-origin-iframes.md))
 
 ## Use cases
 
@@ -50,7 +50,7 @@ To resolve this problem, user agents must only preload pages which either:
 * Indicate that they are prepared to perform this sort of upgrade, by sending the appropriate `Supports-Loading-Mode` header value: either `uncredentialed-prefetch`, `uncredentialed-prerender`, or both.
 
 > **Note**
-> `uncredentialed-prerender` is somewhat speculative at this point; see [cross-site prerendering](prerendering-cross-site.md) for some of the complexity there.
+> `uncredentialed-prerender` is especially speculative at this point; see [cross-site prerendering](prerendering-cross-site.md) for some of the complexity there.
 
 ### Cross-origin same-site prerendering
 

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -146,7 +146,6 @@ spec: COOKIES; urlPrefix: https://httpwg.org/specs/rfc6265.html
 spec: prerendering-revamped; urlPrefix: prerendering.html
   type: dfn
     text: getting the supported loading modes; url: get-the-supported-loading-modes
-    text: uncredentialed-prefetch; for: Supports-Loading-Mode; url: supports-loading-mode-uncredentialed-prefetch
     text: prerendering navigable; url: prerendering-navigable
     text: prerendering traversable; url: prerendering-traversable
 spec: no-vary-search; urlPrefix: https://httpwg.org/http-extensions/draft-ietf-httpbis-no-vary-search.html
@@ -174,9 +173,7 @@ In light of <a href="https://privacycg.github.io/storage-partitioning/">storage 
     1. Let |hypotheticalEnvironment| be the result of [=creating a reserved client=] given |navigable|, |response|'s [=response/URL=], and null.
     1. Let |hypotheticalPartitionKey| be the result of [=determining the network partition key=] given |hypotheticalEnvironment|.
     1. If |hypotheticalPartitionKey| is equal to |sourcePartitionKey| or there are no [=credentials=] associated with [=response/URL=] and |hypotheticalPartitionKey|, then return false.
-    1. Let |loadingModes| be the result of [=getting the supported loading modes=] for |response|.
-    1. If |loadingModes| [=list/contains=] \`<code><a for="Supports-Loading-Mode">uncredentialed-prefetch</a></code>\` then return true.
-    1. Return false.
+    1. Return true.
 </div>
 
 <hr>
@@ -590,7 +587,7 @@ Modify the [=snapshot source snapshot params=] algorithm to set the return value
                     <div class="note">This copy is complete before continuing, in the sense that subresource fetches, {{Document/cookie|document.cookie}}, etc. can observe the cookies. If the prefetch never reached a cross-site URL, there will be no cookies to copy.</div>
                 1. Set |prefetched| to true.
                 1. [=Trigger a prefetch status updated event=] given <var ignore>navigable</var>, |prefetchRecord|, and "{^speculation.PreloadingStatus/success^}" status.
-                
+
                 <p class="note">The guard on these steps means that prefetches are only ever used to fulfill \``GET`\` requests, and only ever activated into [=top-level traversables=].</p>
             1. If |prefetched| is false, then set <var ignore>navigationParams</var> to the result of [=creating navigation params by fetching=] given |request|, <var ignore>entry</var>, <var ignore>navigable</var>, <var ignore>sourceSnapshotParams</var>, <var ignore>targetSnapshotParams</var>, <var ignore>cspNavigationType</var>, <var ignore>navigationId</var>, and <var ignore>navTimingType</var>.
 
@@ -861,7 +858,7 @@ The <dfn>list of sufficiently strict speculative navigation referrer policies</d
         1. If |prefetchRecord|'s [=prefetch record/had conflicting credentials=] is true, then set |navigationParams| to null.
 
             <div class="note">This means that if any cross-partition origin along the redirect chain had credentials (and did not override this behavior using [:Supports-Loading-Mode:]), the prefetch is discarded. This reduces the chance of the user observing a logged-out page when they are logged in.</div>
-            
+
         1. [=Queue a global task=] on the [=networking task source=], given |global|, to:
             1. If |navigationParams| is not a [=navigation params=], then [=prefetch record/cancel and discard=] |prefetchRecord| given |document| and abort these steps.
             1. [=Assert=]: |navigationParams|'s [=navigation params/response=] is the [=exchange record/response=] of |prefetchRecord|'s [=prefetch record/redirect chain=]'s last element.
@@ -1025,7 +1022,7 @@ speculation.PrefetchStatusUpdated = (
 )
 
 speculation.PrefetchStatusUpdatedParameters = {
-   context: text,  
+   context: text,
    url: text,
    status: speculation.PreloadingStatus
 }

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -943,8 +943,6 @@ In some cases, cross-origin web pages might not be prepared to be loaded in a no
 
 The \`<code><dfn export for="Supports-Loading-Mode">credentialed-prerender</dfn></code>\` token indicates that the response can be used to create a [=prerendering navigable=], despite the prerendering being initiated by a cross-origin same-site referrer. Without this opt-in, such prerenders will fail, as outlined in [[#navigate-fetch-patch]].
 
-The \`<code><dfn export for="Supports-Loading-Mode">uncredentialed-prefetch</dfn></code>\` token indicates that the response is suitable to use even if a top-level navigation to this URL would ordinarily send [=credentials=] such as cookies. For instance, the response may be identical or it may be semantically equivalent (e.g., an HTML resource containing script which can update the document after navigation, when local user state is available).
-
 The \`<code><dfn export for="Supports-Loading-Mode">prerender-cross-origin-frames</dfn></code>\` token indicates that the response can be used to prerender all cross-origin iframes. Without this opt-in, such prerenders will be deferred, as outlined in [[#navigate-fetch-patch]].
 
 To <dfn export>get the supported loading modes</dfn> for a [=response=] |response|:


### PR DESCRIPTION
It is not implemented, so as we work toward making the specification ready to usptream into HTML, we should remove it. Closes #400.

The opt-in.md explainer retains a mention of it, along with uncredentialed-prerender, with a bit more clarity that those values are future ideas.

/cc @domfarolino (although this one is pretty straightforward and review isn't that necessary).