### PR TITLE
Do not keep service workers alive via prefetch clients

### DIFF
--- a/prefetch.bs
+++ b/prefetch.bs
@@ -121,6 +121,8 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
         text: anonymization policy; url: sl-candidate-anonymization-policy
       for: speculative load candidate
         text: URL; url: sl-candidate-url
+    urlPrefix: webappapis.html
+      text: navigation and traversal task source
 spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
   type: dfn
     text: network partition key; url: network-partition-key
@@ -786,6 +788,23 @@ This section contains patches to [[SERVICE-WORKERS]].
   <blockquote>
     When a [=service worker client=] has a non-null [=environment/active service worker=]<ins> whose [=environment/is navigational prefetch client=] is false</ins>, it is said to be <dfn noexport>controlled</dfn> by that [=environment/active service worker=].
   </blockquote>
+</div>
+
+<div algorithm="Service Workers Update">
+  Modify the <a spec=SERVICE-WORKERS>Update</a> algorithm by changing the final step as follows:
+
+  1. Else,
+    1. Let |clients| be all [=service worker clients=] whose [=environment/active service worker=] is |worker|.
+    1. [=list/For each=] |client| of |clients|:
+      1. If |client| is not an [=environment settings object=], then [=iteration/continue=].
+      1. If |client|'s [=environment settings object/global object=] is not a {{Window}} object, then [=iteration/continue=].
+      1. [=Queue a global task=] on the [=navigation and traversal task source=] given |client|'s [=environment settings object/global object=] to perform the following steps:
+        1. Let |document| be |client|'s [=environment settings object/global object=]'s [=associated Document=].
+        1. [=list/For each=] |prefetchRecord| of |document|'s [=Document/prefetch records=]:
+          1. [=prefetch record/Cancel and discard=] |prefetchRecord| given |document|.
+
+      <p class="note">Clearing prefetch records in this way avoids a situation where a prefetched response was fetched with the pre-update service worker (<var ignore>newestWorker</var>), but then the navigation results in a client that is controlled by the post-update service worker (|worker|), which could have unexpected consequences for the web developer.</p>
+    1. Invoke <a spec=SERVICE-WORKERS>Install</a> with <var ignore>job</var>, |worker|, and <var ignore>registration</var>.
 </div>
 
 <hr>


### PR DESCRIPTION
Fixes #347: the "clients" created during prefetch time no longer count as controlling pages, in a way that prevents service worker updates. We may still want to consider evicting prefetch records on service worker updates (as discussed in #351), but that can be done as an additional step on top of this.