### PR TITLE
Update makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,11 @@ clean:
 	rm -f $(bikeshed_files:.bs=.html)
 
 %.html: %.bs
-	@ (HTTP_STATUS=$$(curl https://api.csswg.org/bikeshed/ \
+	@ (HTTP_STATUS=$$(curl https://www.w3.org/publications/spec-generator/ \
 	                       --output $@ \
 	                       --write-out "%{http_code}" \
 	                       --header "Accept: text/plain, text/html" \
+												 -F type=bikeshed-spec \
 												 -F die-on=warning \
 	                       -F file=@$<) && \
 	[[ "$$HTTP_STATUS" -eq "200" ]]) || ( \


### PR DESCRIPTION
The current API endpoint returns 302 and it is causing the build fails with Error 22.
More information:
https://github.com/w3c/spec-generator/wiki/Migrating-Bikeshed-HTTP-API-usage-to-spec%E2%80%90generator
Failing example:
https://github.com/WICG/nav-speculation/actions/runs/24172703865/job/70547495575?pr=426