### PR TITLE
Fix link to "delivery type"

### DIFF
--- a/prefetch.bs
+++ b/prefetch.bs
@@ -17,6 +17,7 @@ Boilerplate: omit conformance
 </pre>
 <pre class="link-defaults">
 spec:fetch; type:dfn; text:credentials
+spec:resource-timing; type:dfn; text: delivery type
 </pre>
 <pre class="anchors">
 spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
@@ -152,8 +153,6 @@ spec: no-vary-search; urlPrefix: https://httpwg.org/http-extensions/draft-ietf-h
     text: equivalent modulo search variance; url: name-comparing
   type: http-header
     text: No-Vary-Search; url: name-http-header-field-definitio
-spec: resource-timing; urlPrefix: https://w3c.github.io/resource-timing/
-  type: dfn; for: PerformanceResourceTiming; text: delivery type; url: dfn-delivery-type
 </pre>
 
 <style>


### PR DESCRIPTION
The spec links to the definition of "delivery type" in the "Resource Timing" spec but the fragment ID has changed from `dfn-delivery-type` to `performanceresourcetiming-delivery-type`.

Bikeshed will not auto-link to the definition because that definition is not exported but it still knows about it. This update fixes the link by using a link-default to tell Bikeshed that the link is intended (avoiding the need to hardcod a fragment ID which could perhaps change again).